### PR TITLE
Fixed minio deployment

### DIFF
--- a/start_nevermined.sh
+++ b/start_nevermined.sh
@@ -189,6 +189,8 @@ function start_compute_api {
 
     # add docker images to cache so we don't have to login in the minikube docker env
     minikube cache add keykoio/nevermined-compute-api:latest
+    minikube cache add keykoio/nevermined-pod-config-py:latest
+    minikube cache add keykoio/nevermined-pod-publishing-py:latest
 
     # start the compute-api
     minikube start --mount-string="${DIR}/accounts:/accounts" --mount


### PR DESCRIPTION
## Description

- Fix minio deployment
- added port forwarding for minio to port 8060
- cache remaining docker images for compute stack

Minio is now accessible at `http://localhost:8060`.
The default credentials can be found here https://argoproj.github.io/argo/configure-artifact-repository/#configuring-minio

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation
